### PR TITLE
Header: Added categories in the header menu

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -40,10 +40,14 @@ icon = "envelope"
     weight = 1
     url = "/posts"
   [[menu.header]]
-    name = "tags"
+    name = "categories"
     weight = 2
+    url = "/categories"
+  [[menu.header]]
+    name = "tags"
+    weight = 3
     url = "/tags"
  [[menu.header]]
     name = "about"
-    weight = 3
+    weight = 4
     url = "/about"


### PR DESCRIPTION
I decided to use Hugo's built in tags and categories taxonomies for the content organisation - for now. Therefore, I added a header menu entry to reflect that.